### PR TITLE
Autoloader - checked existence before require.

### DIFF
--- a/lib/ObjectStorage/Util.php
+++ b/lib/ObjectStorage/Util.php
@@ -28,7 +28,7 @@ class ObjectStorage_Util
 
         $path = implode(DIRECTORY_SEPARATOR, $directoryChunks) . '.php';
 
-        if (file_exists( $objectStorageDirectory . '/' . $path)) {
+        if (file_exists($objectStorageDirectory . DIRECTORY_SEPARATOR . $path)) {
             require_once($path);
         }
     }


### PR DESCRIPTION
Autoloader checks for existence. This will avoid issues when using other libraries. Specifically, this broke Doctrine for me.

fixed Util::getMimeByName(). $filename did not exist and this would generate a notice when file didn't match any mime types in lookup array.
