### PR TITLE
Don't automatically reauthenticate on 404 errors

### DIFF
--- a/lib/ObjectStorage/Abstract.php
+++ b/lib/ObjectStorage/Abstract.php
@@ -542,6 +542,8 @@ abstract class ObjectStorage_Abstract
 
         try {
             return $this->objectStorage->get($this);
+        } catch (ObjectStorage_Exception_Http_NotFound $e) {
+            throw $e;
         } catch (Exception $e) {
             $this->objectStorage->reloadAuthenticationData();
             return $this->objectStorage->get($this);
@@ -557,6 +559,8 @@ abstract class ObjectStorage_Abstract
     {
         try {
             return $this->objectStorage->get($this, false);
+        } catch (ObjectStorage_Exception_Http_NotFound $e) {
+            throw $e;
         } catch (Exception $e) {
             $this->objectStorage->reloadAuthenticationData();
             return $this->objectStorage->get($this, false);
@@ -602,6 +606,8 @@ abstract class ObjectStorage_Abstract
     {
         try {
             return $this->objectStorage->delete($this);
+        } catch (ObjectStorage_Exception_Http_NotFound $e) {
+            throw $e;
         } catch (Exception $e) {
             $this->objectStorage->reloadAuthenticationData();
             return $this->objectStorage->delete($this);


### PR DESCRIPTION
GET, HEAD, and DELETE were capturing any exception from the lower level
operation and automatically reauthenticating before retrying. The intent
is to catch expired authentication and transparently retry the
operation.

This is inefficient for querying files that don't exist on object
storage as it will trigger the following flow:

1) GET/HEAD/DELETE is attempted on a non-existent object
2) The original request fails with an Http_NotFound exception
3) Reauthentication is performed against Object Storage
4) The original request is attempted again and the Http_NotFound
   exception is allow to propagate to the caller

Handle this case by explicitly catching an Http_NotFound exception and
rethrowing it at step #2 above
