### PR TITLE
Fix PHPDoc @return value

### DIFF
--- a/lib/ObjectStorage/TokenStore.php
+++ b/lib/ObjectStorage/TokenStore.php
@@ -29,7 +29,7 @@ class ObjectStorage_TokenStore
      *
      * @throws ObjectStorage_Exception_TokenStore
      *
-     * @return ObjectStorage_TokenStore
+     * @return ObjectStorage_TokenStore_Interface
      */
     public static function factory($type, $config = array())
     {


### PR DESCRIPTION
`TokenStore::factory()` returns an object implementing `ObjectStorage_TokenStore_Interface`, not `ObjectStorage_TokenStore` itself.
