### PR TITLE
Add "connect_timeout" option for cURL.

### DIFF
--- a/lib/ObjectStorage.php
+++ b/lib/ObjectStorage.php
@@ -12,6 +12,7 @@ class ObjectStorage
 {
     protected $httpClient;
     protected $httpClientAdapterTimeout = 10;
+    protected $httpClientAdapterConnectTimeout = null;
     protected $httpClientAdapterIdendifier;
 
     protected $objectStorageHost;
@@ -67,7 +68,11 @@ class ObjectStorage
         }
 
         if (isset($options['timeout'])) {
-            $this->httpClientAdapterTimeout    = $options['timeout'];
+            $this->httpClientAdapterTimeout = $options['timeout'];
+        }
+
+        if (isset($options['connect_timeout'])) {
+            $this->httpClientAdapterConnectTimeout = $options['connect_timeout'];
         }
     }
 
@@ -188,7 +193,10 @@ class ObjectStorage
     protected function getHttpClient()
     {
         if (! isset($this->httpClient)) {
-            $this->httpClient = ObjectStorage_Http_Client::factory($this->httpClientAdapterIdendifier, array('timeout' => $this->httpClientAdapterTimeout));
+            $this->httpClient = ObjectStorage_Http_Client::factory($this->httpClientAdapterIdendifier, array(
+                'timeout'         => $this->httpClientAdapterTimeout,
+                'connect_timeout' => $this->httpClientAdapterConnectTimeout,
+            ));
         }
         // Remove previous request headers and other trails
         $this->httpClient->reset();

--- a/lib/ObjectStorage/Http/Adapter/Curl.php
+++ b/lib/ObjectStorage/Http/Adapter/Curl.php
@@ -12,6 +12,7 @@ class ObjectStorage_Http_Adapter_Curl implements ObjectStorage_Http_Adapter_Inte
     protected $body;
     protected $method;
     protected $timeout = 30;
+    protected $connectTimeout = null;
     protected $requestHeaders = array();
     protected $fileHandler = null;
 
@@ -29,6 +30,10 @@ class ObjectStorage_Http_Adapter_Curl implements ObjectStorage_Http_Adapter_Inte
 
         if (isset($options['timeout']) && is_numeric($options['timeout'])) {
             $this->timeout = $options['timeout'];
+        }
+
+        if (isset($options['connect_timeout']) && is_numeric($options['connect_timeout'])) {
+            $this->connectTimeout = $options['connect_timeout'];
         }
     }
 
@@ -117,6 +122,10 @@ class ObjectStorage_Http_Adapter_Curl implements ObjectStorage_Http_Adapter_Inte
         curl_setopt($curl, CURLOPT_URL, $this->uri);
         curl_setopt($curl, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($curl, CURLOPT_HTTPHEADER, array($requestHeaders));
+
+        if ( $this->connectTimeout !== null ) {
+            curl_setopt($curl, CURLOPT_CONNECTTIMEOUT, $this->connectTimeout);
+        }
 
         $method = strtoupper($this->method);
         switch($method) {


### PR DESCRIPTION
Add `connect_timeout` option. However, this currently affects cURL only.

Zend's HTTP client apparently only has a connect timeout, not a timeout for an established link or the entire request, so using `connect_timeout` would actually be more applicable than the existing `timeout` option, but this is a semantic change, though not necessarily backwards-incompatible (we could prefer `connect_timeout` if it is not `NULL` and fall back to `timeout` otherwise).

PHP's [`fsockopen()`'s](http://php.net/manual/en/function.fsockopen.php) `$timeout` parameter also refers to a connection timeout rather than a request timeout, which can be specified with [`stream_set_timeout`](http://php.net/manual/en/function.stream-set-timeout.php).